### PR TITLE
pek dev mot dp-inntekt-api-q1

### DIFF
--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -1,5 +1,5 @@
 ingresses:
   - "https://dagpenger-regel-ui.intern.dev.nav.no/"
 inntekt_api:
-  ingress: dp-inntekt-api.intern.dev.nav.no
-  audience: api://dev-gcp.teamdagpenger.dp-inntekt-api/.default
+  ingress: dp-inntekt-api-q1.intern.dev.nav.no
+  audience: api://dev-gcp.teamdagpenger.dp-inntekt-api-q1/.default


### PR DESCRIPTION
Data ligger i q1-databasen etter at alle apper ble flyttet til q2. Oppdaterer vars-dev.yaml til å peke på ekstern ingress for q1-instansen.